### PR TITLE
style: fix header layout shift

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -8,8 +8,8 @@ import {Site} from "@/config";
     </h1>
     <div class="lg:flex text-center justify-between">
         <p class="text-lg text-gray-600">{Site.description}</p>
-        <nav class="my-auto">
-            <ul class="justify-center flex flex-wrap list-disc list-inside">
+        <nav class="my-0">
+            <ul class="my-0 justify-center flex flex-wrap list-disc list-inside">
                 {Site.menu.icons.map(({clz, url}) => (
                         <li class="list-none mx-2">
                             <a class="text-gray-600" href={url}>

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,9 +8,9 @@ export const Site = {
     menu: {
         navs: [
             {name: "Home", url: "/"},
-            {name: "About", url: "/about"},
             {name: "Categories", url: "/categories"},
             {name: "Tags", url: "/tags"},
+            {name: "About", url: "/about"},
         ],
         icons: [
             {


### PR DESCRIPTION
During icon loading because of its late appearance, its extra margin causes the layout to shift. 
So I removed the icon's margin.

By the way, I adjusted the position of `about` in the nav. Now it looks more in line with the common layout.